### PR TITLE
Fix cron permissions

### DIFF
--- a/packages/core/types/BaseEvent.ts
+++ b/packages/core/types/BaseEvent.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const BaseEvent = z.object({
+  eventId: z.string().optional(),
+});
+
+export type BaseEvent = z.infer<typeof BaseEvent>;

--- a/packages/core/types/cron/index.ts
+++ b/packages/core/types/cron/index.ts
@@ -1,0 +1,4 @@
+export const iceBreaker = "iceBreaker";
+export const daily = "daily";
+
+export type ScheduledEventType = typeof iceBreaker | typeof daily;

--- a/packages/core/types/events/index.ts
+++ b/packages/core/types/events/index.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 
-const BaseEvent = z.object({
-  eventId: z.string().optional(),
-});
+import { BaseEvent } from "@/types/BaseEvent";
 
 const Events = z.object({
   memberJoinedChannel: BaseEvent.extend({

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -6,7 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@/db/*": ["../core/db/*"],
-      "@/events": ["../core/events/index.ts"],
+      "@/events": ["../core/types/events/index.ts"],
       "@/services/*": ["../core/services/*"],
       "@/utils/*": ["utils/*"],
       "@/types/*": ["../core/types/*"]

--- a/packages/functions/utils/lambda/cronHandler.ts
+++ b/packages/functions/utils/lambda/cronHandler.ts
@@ -1,8 +1,11 @@
 import type { APIGatewayProxyEventV2, EventBridgeEvent } from "aws-lambda";
 
+import type { BaseEvent } from "@/types/BaseEvent";
+import type { ScheduledEventType } from "@/types/cron";
+
 type Event =
   | APIGatewayProxyEventV2
-  | EventBridgeEvent<"Scheduled Event", unknown>;
+  | EventBridgeEvent<ScheduledEventType, BaseEvent>;
 
 const isApiGatewayProxyEventV2 = (
   event: Event,
@@ -14,7 +17,7 @@ export const cronHandler =
     try {
       const eventId = isApiGatewayProxyEventV2(request)
         ? request.queryStringParameters?.eventId
-        : undefined;
+        : request.detail.eventId;
 
       await handler(eventId);
     } catch (error) {

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -2,6 +2,7 @@ import type { SSTConfig } from "sst";
 
 import { ConfigStack } from "./stacks/ConfigStack";
 import { CronStack } from "./stacks/CronStack";
+import { EventBusStack } from "./stacks/EventBusStack";
 import { MyStack } from "./stacks/MyStack";
 import { StorageStack } from "./stacks/StorageStack";
 
@@ -13,6 +14,11 @@ export default {
     };
   },
   stacks(app) {
-    app.stack(ConfigStack).stack(StorageStack).stack(CronStack).stack(MyStack);
+    app
+      .stack(ConfigStack)
+      .stack(StorageStack)
+      .stack(EventBusStack)
+      .stack(MyStack)
+      .stack(CronStack);
   },
 } satisfies SSTConfig;

--- a/stacks/CronStack.ts
+++ b/stacks/CronStack.ts
@@ -1,40 +1,46 @@
 import type { StackContext } from "sst/constructs";
-import { Cron, use } from "sst/constructs";
+import { Cron } from "sst/constructs";
 
-import { ConfigStack } from "./ConfigStack";
+import { daily, iceBreaker } from "@/types/cron";
+
+import { getFunctionProps } from "./getFunctionProps";
 
 export function CronStack({ stack }: StackContext) {
-  const secrets = use(ConfigStack);
+  const functionProps = getFunctionProps();
 
-  const environment = {
-    DB_URL: process.env.DB_URL || "",
-  };
-
-  const icebreakerCron = new Cron(stack, "Cron", {
+  new Cron(stack, "IceBreakerCron", {
     job: {
       function: {
-        environment,
         handler: "packages/functions/cron/iceBreakerQuestions.handler",
-        runtime: "nodejs18.x",
+        ...functionProps,
+      },
+    },
+    cdk: {
+      rule: {
+        eventPattern: {
+          detailType: [iceBreaker],
+        },
       },
     },
     // Every first Tuesday of the month at 11:00 UTC
     schedule: "cron(0 11 ? * 3#1 *)",
   });
 
-  icebreakerCron.bind(secrets);
-
-  const dailyCron = new Cron(stack, "DailyCron", {
+  new Cron(stack, "DailyCron", {
     job: {
       function: {
-        environment,
         handler: "packages/functions/cron/daily.handler",
-        runtime: "nodejs18.x",
+        ...functionProps,
+      },
+    },
+    cdk: {
+      rule: {
+        eventPattern: {
+          detailType: [daily],
+        },
       },
     },
     // Every day at 11:00 UTC
     schedule: "cron(0 11 ? * * *)",
   });
-
-  dailyCron.bind(secrets);
 }

--- a/stacks/EventBusStack.ts
+++ b/stacks/EventBusStack.ts
@@ -1,0 +1,13 @@
+import { EventBus, type StackContext } from "sst/constructs";
+
+export function EventBusStack({ stack }: StackContext) {
+  const eventBus = new EventBus(stack, "EventBus", {});
+
+  stack.addOutputs({
+    eventBusName: eventBus.eventBusName,
+  });
+
+  return {
+    eventBus,
+  };
+}

--- a/stacks/getFunctionProps.ts
+++ b/stacks/getFunctionProps.ts
@@ -1,0 +1,23 @@
+import { use } from "sst/constructs";
+
+import { ConfigStack } from "./ConfigStack";
+import { EventBusStack } from "./EventBusStack";
+import { StorageStack } from "./StorageStack";
+
+export const getFunctionProps = () => {
+  const secrets = use(ConfigStack);
+  const { db } = use(StorageStack);
+  const { eventBus } = use(EventBusStack);
+
+  const bind = [...secrets, ...(db ? [db] : [])];
+
+  return {
+    permissions: [eventBus],
+    environment: {
+      EVENT_BUS_NAME: eventBus.eventBusName,
+      DB_URL: process.env.DB_URL || "",
+    },
+    bind,
+    runtime: "nodejs18.x" as const,
+  };
+};

--- a/tests/integration/askPresentIdeas.test.ts
+++ b/tests/integration/askPresentIdeas.test.ts
@@ -7,6 +7,7 @@ import { presentIdeas, testItems, users } from "@/db/schema";
 import { constructPresentIdeaSavedMessage } from "@/services/slack/constructPresentIdeaSavedMessage";
 import { pollInterval, timeout, waitTimeout } from "@/testUtils/constants";
 import { deleteLastDm } from "@/testUtils/integration/deleteLastDm";
+import { sendCronEvent } from "@/testUtils/integration/sendCronEvent";
 import { sendSlackInteraction } from "@/testUtils/integration/sendSlackInteraction";
 import { waitForDm } from "@/testUtils/integration/waitForDm";
 import { testDb, waitForTestItem } from "@/testUtils/testDb";
@@ -57,7 +58,7 @@ describe("Present ideas", () => {
 
       const eventId = "PI1_" + Date.now().toString();
 
-      await fetch(`${import.meta.env.VITE_API_URL}/daily?eventId=${eventId}`);
+      await sendCronEvent("daily", eventId);
 
       const message = await waitForDm(eventId);
 

--- a/tests/integration/iceBreakerQuestions.test.ts
+++ b/tests/integration/iceBreakerQuestions.test.ts
@@ -8,6 +8,7 @@ import {
   usersInWindow,
   usersOutsideWindow,
 } from "@/testUtils/generateIceBreakerTestUsers";
+import { sendCronEvent } from "@/testUtils/integration/sendCronEvent";
 import { app } from "@/testUtils/integration/testSlackApp";
 import { waitForPostInRandom } from "@/testUtils/integration/waitForPostInRandom";
 import { testDb } from "@/testUtils/testDb";
@@ -53,9 +54,7 @@ describe("Icebreaker questions", () => {
     async () => {
       const eventId = "IB1_" + Date.now().toString();
 
-      await fetch(
-        `${import.meta.env.VITE_API_URL}/icebreaker?eventId=${eventId}`,
-      );
+      await sendCronEvent("iceBreaker", eventId);
 
       const message = await waitForPostInRandom(eventId);
 
@@ -74,9 +73,7 @@ describe("Icebreaker questions", () => {
 
       const eventId = "IB2_" + Date.now().toString();
 
-      await fetch(
-        `${import.meta.env.VITE_API_URL}/icebreaker?eventId=${eventId}`,
-      );
+      await sendCronEvent("iceBreaker", eventId);
 
       const message = await waitForPostInRandom(eventId);
 
@@ -109,9 +106,7 @@ describe("Icebreaker questions", () => {
 
       const eventId = "IB3_" + Date.now().toString();
 
-      await fetch(
-        `${import.meta.env.VITE_API_URL}/icebreaker?eventId=${eventId}`,
-      );
+      await sendCronEvent("iceBreaker", eventId);
 
       const threads = await vi.waitFor(
         async () => {

--- a/tests/utils/integration/sendCronEvent.ts
+++ b/tests/utils/integration/sendCronEvent.ts
@@ -1,0 +1,27 @@
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+
+import type { ScheduledEventType } from "@/types/cron";
+
+const eventBridge = new EventBridgeClient();
+
+export const sendCronEvent = async (
+  type: ScheduledEventType,
+  eventId: string,
+) => {
+  await eventBridge.send(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Detail: JSON.stringify({
+            eventId,
+          }),
+          DetailType: type,
+          Source: "sst",
+        },
+      ],
+    }),
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "baseUrl": ".",
     "paths": {
       "@/db/*": ["packages/core/db/*"],
-      "@/events": ["packages/core/events/index.ts"],
+      "@/events": ["packages/core/types/events/index.ts"],
       "@/functions/*": ["packages/functions/*"],
       "@/services/*": ["packages/core/services/*"],
       "@/types/*": ["packages/core/types/*"],


### PR DESCRIPTION
Cron job handlers didn't have the same inputs (i.e env vars, bind-s, runtime-s) as api gateway handlers and the tests didn't catch this.

- Moved function input creation to separate function so each function will have the same.
- Tests are now invoking cron-s instead of apigateway. (left the lambdas there for manual testing but they don't have a real purpose atm)