### PR TITLE
APEX-1634 Create birthday squad

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,6 +66,8 @@ jobs:
           npx sst secrets set SLACK_SIGNING_SECRET "${{ secrets.SLACK_SIGNING_SECRET_TEST }}" --stage ${{ env.STAGE }}
           npx sst secrets set CORE_SLACK_CHANNEL_ID "${{ secrets.CORE_SLACK_CHANNEL_ID_TEST }}" --stage ${{ env.STAGE }}
           npx sst secrets set RANDOM_SLACK_CHANNEL_ID "${{ secrets.RANDOM_SLACK_CHANNEL_ID_TEST }}" --stage ${{ env.STAGE }}
+          npx sst secrets set KRISZTA_SLACK_USER_ID "${{ secrets.SLACK_USER_ID_TEST }}" --stage ${{ env.STAGE }}
+          npx sst secrets set MATE_SLACK_USER_ID "${{ secrets.SLACK_USER_ID_TEST }}" --stage ${{ env.STAGE }}
 
       - name: Deploy stack
         run: pnpm run deploy --stage ${{ env.STAGE }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -54,6 +54,8 @@ jobs:
           npx sst secrets set SLACK_SIGNING_SECRET "${{ secrets.SLACK_SIGNING_SECRET_PRODUCTION}}" --stage "${{ env.stage }}"
           npx sst secrets set CORE_SLACK_CHANNEL_ID "${{ secrets.CORE_SLACK_CHANNEL_ID_PRODUCTION}}" --stage "${{ env.stage }}"
           npx sst secrets set RANDOM_SLACK_CHANNEL_ID "${{ secrets.RANDOM_SLACK_CHANNEL_ID_PRODUCTION}}" --stage "${{ env.stage }}"
+          npx sst secrets set KRISZTA_SLACK_USER_ID "${{ secrets.KRISZTA_SLACK_USER_ID_PRODUCTION }}" --stage ${{ env.STAGE }}
+          npx sst secrets set MATE_SLACK_USER_ID "${{ secrets.MATE_SLACK_USER_ID_PRODUCTION }}" --stage ${{ env.STAGE }}
 
       - name: Deploy stack
         run: pnpm run deploy --stage "${{ env.stage }}"

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -55,6 +55,8 @@ jobs:
           npx sst secrets set SLACK_SIGNING_SECRET "${{ secrets.SLACK_SIGNING_SECRET_STAGING }}" --stage "${{ env.stage }}"
           npx sst secrets set CORE_SLACK_CHANNEL_ID "${{ secrets.CORE_SLACK_CHANNEL_ID_STAGING }}" --stage "${{ env.stage }}"
           npx sst secrets set RANDOM_SLACK_CHANNEL_ID "${{ secrets.RANDOM_SLACK_CHANNEL_ID_STAGING }}" --stage "${{ env.stage }}"
+          npx sst secrets set KRISZTA_SLACK_USER_ID "${{ secrets.KRISZTA_SLACK_USER_ID_STAGING }}" --stage ${{ env.STAGE }}
+          npx sst secrets set MATE_SLACK_USER_ID "${{ secrets.MATE_SLACK_USER_ID_STAGING }}" --stage ${{ env.STAGE }}
 
       - name: Deploy stack
         run: pnpm run deploy --stage "${{ env.stage }}"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Helps teams to find the best birthday gift for their colleagues.
 - groups:history
 - im:history
 - mpim:history
+- mpim:write
 
 5. Open the `Event Subscriptions` sub-page -> enable events. (We will add the url later.)
 6. Scroll below `Subscribe to bot events` and add these scopes:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ npx sst secrets set SLACK_BOT_TOKEN <your-bot-token>
 npx sst secrets set SLACK_SIGNING_SECRET <your-signing-secret>
 npx sst secrets set CORE_SLACK_CHANNEL_ID <your-test-channel>
 npx sst secrets set RANDOM_SLACK_CHANNEL_ID <your-test-channel>
+npx sst secrets set KRISZTA_SLACK_USER_ID <your-test-user>
+npx sst secrets set MATE_SLACK_USER_ID <your-test-user>
 ```
 
 3. Install dependencies: `pnpm i`

--- a/packages/core/db/migrations/0006_squad_joins_unique.sql
+++ b/packages/core/db/migrations/0006_squad_joins_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "squadJoins" ADD CONSTRAINT "squadJoins_birthday_person_user_id_team_id_unique" UNIQUE("birthday_person","user_id","team_id");

--- a/packages/core/db/migrations/meta/0006_snapshot.json
+++ b/packages/core/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,269 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "7a144ed2-c59c-4a83-9557-a5cedefcf53a",
+  "prevId": "b30847cb-9309-4644-bdb9-dbae4e89caa0",
+  "tables": {
+    "iceBreakerThreads": {
+      "name": "iceBreakerThreads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "iceBreakerThreads_user_id_team_id_users_id_team_id_fk": {
+          "name": "iceBreakerThreads_user_id_team_id_users_id_team_id_fk",
+          "tableFrom": "iceBreakerThreads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id",
+            "team_id"
+          ],
+          "columnsTo": [
+            "id",
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "presentIdeas": {
+      "name": "presentIdeas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_person": {
+          "name": "birthday_person",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "present_idea": {
+          "name": "present_idea",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "presentIdeas_user_id_team_id_users_id_team_id_fk": {
+          "name": "presentIdeas_user_id_team_id_users_id_team_id_fk",
+          "tableFrom": "presentIdeas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id",
+            "team_id"
+          ],
+          "columnsTo": [
+            "id",
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "presentIdeas_birthday_person_team_id_users_id_team_id_fk": {
+          "name": "presentIdeas_birthday_person_team_id_users_id_team_id_fk",
+          "tableFrom": "presentIdeas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "birthday_person",
+            "team_id"
+          ],
+          "columnsTo": [
+            "id",
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "squadJoins": {
+      "name": "squadJoins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_person": {
+          "name": "birthday_person",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "squadJoins_user_id_team_id_users_id_team_id_fk": {
+          "name": "squadJoins_user_id_team_id_users_id_team_id_fk",
+          "tableFrom": "squadJoins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id",
+            "team_id"
+          ],
+          "columnsTo": [
+            "id",
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "squadJoins_birthday_person_team_id_users_id_team_id_fk": {
+          "name": "squadJoins_birthday_person_team_id_users_id_team_id_fk",
+          "tableFrom": "squadJoins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "birthday_person",
+            "team_id"
+          ],
+          "columnsTo": [
+            "id",
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "squadJoins_birthday_person_user_id_team_id_unique": {
+          "name": "squadJoins_birthday_person_user_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "birthday_person",
+            "user_id",
+            "team_id"
+          ]
+        }
+      }
+    },
+    "testItems": {
+      "name": "testItems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id_team_id": {
+          "name": "users_id_team_id",
+          "columns": [
+            "id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/core/db/migrations/meta/_journal.json
+++ b/packages/core/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1699867144665,
       "tag": "0005_squad_joins",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "5",
+      "when": 1700142341811,
+      "tag": "0006_squad_joins_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/db/queries/getSquadMembers.ts
+++ b/packages/core/db/queries/getSquadMembers.ts
@@ -1,0 +1,53 @@
+import { and, eq, not, sql } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { squadJoins, users } from "@/db/schema";
+
+type RandomSquadMembersInput = {
+  teamId: string;
+  usersToExclude: string[];
+  limit: number;
+};
+
+export const getSquadMembers = async (
+  teamId: string,
+  birthdayPersonId: string,
+) => {
+  const squadMembers = await db
+    .select({
+      id: squadJoins.userId,
+    })
+    .from(squadJoins)
+    .where(
+      and(
+        eq(squadJoins.teamId, teamId),
+        eq(squadJoins.birthdayPerson, birthdayPersonId),
+      ),
+    )
+    .orderBy(sql`RANDOM()`)
+    .limit(5);
+
+  return squadMembers.map((member) => member.id);
+};
+
+export const getRandomSquadMembers = async ({
+  teamId,
+  usersToExclude,
+  limit,
+}: RandomSquadMembersInput) => {
+  const teammates = await db
+    .select({
+      id: users.id,
+    })
+    .from(users)
+    .where(
+      and(
+        eq(users.teamId, teamId),
+        ...usersToExclude.map((userId) => not(eq(users.id, userId))),
+      ),
+    )
+    .orderBy(sql`RANDOM()`)
+    .limit(limit);
+
+  return teammates.map((teammate) => teammate.id);
+};

--- a/packages/core/db/schema.ts
+++ b/packages/core/db/schema.ts
@@ -4,6 +4,7 @@ import {
   pgTable,
   primaryKey,
   serial,
+  unique,
   varchar,
 } from "drizzle-orm/pg-core";
 
@@ -75,6 +76,7 @@ export const squadJoins = pgTable(
       columns: [t.birthdayPerson, t.teamId],
       foreignColumns: [users.id, users.teamId],
     }).onDelete("cascade"),
+    unq: unique().on(t.birthdayPerson, t.userId, t.teamId),
   }),
 );
 

--- a/packages/core/services/slack/openConversation.ts
+++ b/packages/core/services/slack/openConversation.ts
@@ -1,0 +1,13 @@
+import { createSlackApp } from "./createSlackApp";
+
+export const openConversation = async (userIds: string[]): Promise<string> => {
+  const app = createSlackApp();
+  const { channel } = await app.client.conversations.open({
+    users: userIds.join(","),
+  });
+
+  if (!channel?.id) {
+    throw new Error("Error while opening conversation");
+  }
+  return channel?.id;
+};

--- a/packages/core/types/events/index.ts
+++ b/packages/core/types/events/index.ts
@@ -56,6 +56,15 @@ const Events = z.object({
     birthdayPerson: z.string(),
     user: z.string(),
   }),
+  createBirthdaySquad: BaseEvent.extend({
+    birthdayPerson: z.string(),
+    team: z.string(),
+  }),
+  sendSquadWelcomeMessage: BaseEvent.extend({
+    birthdayPerson: z.string(),
+    conversationId: z.string(),
+    team: z.string(),
+  }),
 });
 
 export type Events = z.infer<typeof Events>;

--- a/packages/functions/cron/iceBreakerQuestions.ts
+++ b/packages/functions/cron/iceBreakerQuestions.ts
@@ -27,13 +27,15 @@ export const handler = cronHandler(async (eventId?: string) => {
       throw new Error("Failed to send ice breaker question");
     }
 
-    await db.insert(iceBreakerThreads).values(
-      users.map((user) => ({
-        userId: user.id,
-        teamId: user.teamId,
-        threadId: message.ts!,
-      })),
-    );
+    if (users.length) {
+      await db.insert(iceBreakerThreads).values(
+        users.map((user) => ({
+          userId: user.id,
+          teamId: user.teamId,
+          threadId: message.ts!,
+        })),
+      );
+    }
 
     return {
       message: "Ice breaker question sent",

--- a/packages/functions/events/askPresentIdeasFromTeam.ts
+++ b/packages/functions/events/askPresentIdeasFromTeam.ts
@@ -26,6 +26,15 @@ export const handler = handleEvent(
         },
         4,
       );
+      await publishScheduledEvent(
+        "createBirthdaySquad",
+        {
+          birthdayPerson,
+          team,
+          eventId,
+        },
+        8,
+      );
     } catch (error) {
       console.error("Error processing askPresentIdeasFromTeam event: ", error);
     }

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -27,6 +27,10 @@ export const handler = handleEvent(
         squadMembers.push(...randomSquadMember);
       }
 
+      if (squadMembers.length < 2) {
+        throw new Error("Error need at least 2 user to open a conversation");
+      }
+
       const conversationId = await openConversation(squadMembers);
 
       publishEvent("sendSquadWelcomeMessage", {

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -5,6 +5,8 @@ import {
 import { openConversation } from "@/services/slack/openConversation";
 import {
   BIRTHDAY_SQUAD_SIZE,
+  KRISZTA_USER_ID,
+  MATE_USER_ID,
   MIN_BIRTHDAY_SQUAD_SIZE,
 } from "@/utils/constants";
 import { handleEvent } from "@/utils/eventBridge/handleEvent";
@@ -26,6 +28,11 @@ export const handler = handleEvent(
         });
         squadMembers.push(...randomSquadMembers);
       }
+
+      // Include Kriszta in all squads except on her birthday, where Mate is added to the squad.
+      squadMembers.push(
+        birthdayPerson !== KRISZTA_USER_ID ? KRISZTA_USER_ID : MATE_USER_ID,
+      );
 
       if (squadMembers.length < 2) {
         throw new Error("Error need at least 2 user to open a conversation");

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -17,6 +17,12 @@ export const handler = handleEvent(
   async ({ team, birthdayPerson, eventId }) => {
     const { KRISZTA_SLACK_USER_ID, MATE_SLACK_USER_ID } = Config;
 
+    // Include Kriszta in all squads except on her birthday, where Mate is added to the squad.
+    const adminPerson =
+      birthdayPerson !== KRISZTA_SLACK_USER_ID
+        ? KRISZTA_SLACK_USER_ID
+        : MATE_SLACK_USER_ID;
+
     try {
       const appliedSquadMembers = await getSquadMembers(team, birthdayPerson);
 
@@ -25,18 +31,13 @@ export const handler = handleEvent(
       if (appliedSquadMembers.length < MIN_BIRTHDAY_SQUAD_SIZE) {
         const randomSquadMembers = await getRandomSquadMembers({
           teamId: team,
-          usersToExclude: [birthdayPerson, ...appliedSquadMembers],
+          usersToExclude: [birthdayPerson, adminPerson, ...appliedSquadMembers],
           limit: BIRTHDAY_SQUAD_SIZE - appliedSquadMembers.length,
         });
         squadMembers.push(...randomSquadMembers);
       }
 
-      // Include Kriszta in all squads except on her birthday, where Mate is added to the squad.
-      squadMembers.push(
-        birthdayPerson !== KRISZTA_SLACK_USER_ID
-          ? KRISZTA_SLACK_USER_ID
-          : MATE_SLACK_USER_ID,
-      );
+      squadMembers.push(adminPerson);
 
       if (squadMembers.length < 2) {
         throw new Error("Error need at least 2 user to open a conversation");

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -1,3 +1,5 @@
+import { Config } from "sst/node/config";
+
 import {
   getRandomSquadMembers,
   getSquadMembers,
@@ -5,8 +7,6 @@ import {
 import { openConversation } from "@/services/slack/openConversation";
 import {
   BIRTHDAY_SQUAD_SIZE,
-  KRISZTA_USER_ID,
-  MATE_USER_ID,
   MIN_BIRTHDAY_SQUAD_SIZE,
 } from "@/utils/constants";
 import { handleEvent } from "@/utils/eventBridge/handleEvent";
@@ -15,6 +15,8 @@ import { publishEvent } from "@/utils/eventBridge/publishEvent";
 export const handler = handleEvent(
   "createBirthdaySquad",
   async ({ team, birthdayPerson, eventId }) => {
+    const { KRISZTA_SLACK_USER_ID, MATE_SLACK_USER_ID } = Config;
+
     try {
       const appliedSquadMembers = await getSquadMembers(team, birthdayPerson);
 
@@ -31,7 +33,9 @@ export const handler = handleEvent(
 
       // Include Kriszta in all squads except on her birthday, where Mate is added to the squad.
       squadMembers.push(
-        birthdayPerson !== KRISZTA_USER_ID ? KRISZTA_USER_ID : MATE_USER_ID,
+        birthdayPerson !== KRISZTA_SLACK_USER_ID
+          ? KRISZTA_SLACK_USER_ID
+          : MATE_SLACK_USER_ID,
       );
 
       if (squadMembers.length < 2) {

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -1,0 +1,42 @@
+import {
+  getRandomSquadMembers,
+  getSquadMembers,
+} from "@/db/queries/getSquadMembers";
+import { openConversation } from "@/services/slack/openConversation";
+import {
+  BIRTHDAY_SQUAD_SIZE,
+  MIN_BIRTHDAY_SQUAD_SIZE,
+} from "@/utils/constants";
+import { handleEvent } from "@/utils/eventBridge/handleEvent";
+import { publishEvent } from "@/utils/eventBridge/publishEvent";
+
+export const handler = handleEvent(
+  "createBirthdaySquad",
+  async ({ team, birthdayPerson, eventId }) => {
+    try {
+      const appliedSquadMembers = await getSquadMembers(team, birthdayPerson);
+
+      const squadMembers = [...appliedSquadMembers];
+
+      if (appliedSquadMembers.length < MIN_BIRTHDAY_SQUAD_SIZE) {
+        const randomSquadMember = await getRandomSquadMembers({
+          teamId: team,
+          usersToExclude: [birthdayPerson, ...appliedSquadMembers],
+          limit: BIRTHDAY_SQUAD_SIZE - appliedSquadMembers.length,
+        });
+        squadMembers.push(...randomSquadMember);
+      }
+
+      const conversationId = await openConversation(squadMembers);
+
+      publishEvent("sendSquadWelcomeMessage", {
+        conversationId,
+        birthdayPerson,
+        team,
+        eventId,
+      });
+    } catch (error) {
+      console.error("Error processing createBirthdaySquad event: ", error);
+    }
+  },
+);

--- a/packages/functions/events/createBirthdaySquad.ts
+++ b/packages/functions/events/createBirthdaySquad.ts
@@ -19,12 +19,12 @@ export const handler = handleEvent(
       const squadMembers = [...appliedSquadMembers];
 
       if (appliedSquadMembers.length < MIN_BIRTHDAY_SQUAD_SIZE) {
-        const randomSquadMember = await getRandomSquadMembers({
+        const randomSquadMembers = await getRandomSquadMembers({
           teamId: team,
           usersToExclude: [birthdayPerson, ...appliedSquadMembers],
           limit: BIRTHDAY_SQUAD_SIZE - appliedSquadMembers.length,
         });
-        squadMembers.push(...randomSquadMember);
+        squadMembers.push(...randomSquadMembers);
       }
 
       if (squadMembers.length < 2) {
@@ -33,7 +33,7 @@ export const handler = handleEvent(
 
       const conversationId = await openConversation(squadMembers);
 
-      publishEvent("sendSquadWelcomeMessage", {
+      await publishEvent("sendSquadWelcomeMessage", {
         conversationId,
         birthdayPerson,
         team,

--- a/packages/functions/events/sendSquadWelcomeMessage.ts
+++ b/packages/functions/events/sendSquadWelcomeMessage.ts
@@ -1,0 +1,18 @@
+import { handleEvent } from "@/utils/eventBridge/handleEvent";
+
+//TODO APEX-1562
+export const handler = handleEvent(
+  "sendSquadWelcomeMessage",
+  async ({ team, birthdayPerson, conversationId, eventId }) => {
+    try {
+      console.info({
+        team,
+        birthdayPerson,
+        conversationId,
+        eventId,
+      });
+    } catch (error) {
+      console.error("Error processing sendSquadWelcomeMessage event: ", error);
+    }
+  },
+);

--- a/packages/functions/events/sendSquadWelcomeMessage.ts
+++ b/packages/functions/events/sendSquadWelcomeMessage.ts
@@ -1,3 +1,4 @@
+import { createSlackApp } from "@/services/slack/createSlackApp";
 import { handleEvent } from "@/utils/eventBridge/handleEvent";
 
 //TODO APEX-1562
@@ -10,6 +11,21 @@ export const handler = handleEvent(
         birthdayPerson,
         conversationId,
         eventId,
+      });
+
+      //TODO APEX-1562
+      const app = createSlackApp();
+      await app.client.chat.postMessage({
+        channel: conversationId,
+        metadata: eventId
+          ? {
+              event_type: "sendSquadWelcomeMessage",
+              event_payload: {
+                eventId,
+              },
+            }
+          : undefined,
+        text: "Test message",
       });
     } catch (error) {
       console.error("Error processing sendSquadWelcomeMessage event: ", error);

--- a/packages/functions/utils/constants.ts
+++ b/packages/functions/utils/constants.ts
@@ -1,2 +1,4 @@
 export const MIN_BIRTHDAY_SQUAD_SIZE = 3;
 export const BIRTHDAY_SQUAD_SIZE = 5;
+export const KRISZTA_USER_ID = "U05RHGX7Z6K";
+export const MATE_USER_ID = "U056WGLBNNB";

--- a/packages/functions/utils/constants.ts
+++ b/packages/functions/utils/constants.ts
@@ -1,0 +1,2 @@
+export const MIN_BIRTHDAY_SQUAD_SIZE = 3;
+export const BIRTHDAY_SQUAD_SIZE = 5;

--- a/packages/functions/utils/constants.ts
+++ b/packages/functions/utils/constants.ts
@@ -1,4 +1,2 @@
 export const MIN_BIRTHDAY_SQUAD_SIZE = 3;
 export const BIRTHDAY_SQUAD_SIZE = 5;
-export const KRISZTA_USER_ID = "U05RHGX7Z6K";
-export const MATE_USER_ID = "U056WGLBNNB";

--- a/stacks/ConfigStack.ts
+++ b/stacks/ConfigStack.ts
@@ -13,6 +13,11 @@ export function ConfigStack({ stack }: StackContext) {
     stack,
     "RANDOM_SLACK_CHANNEL_ID",
   );
+  const KRISZTA_SLACK_USER_ID = new Config.Secret(
+    stack,
+    "KRISZTA_SLACK_USER_ID",
+  );
+  const MATE_SLACK_USER_ID = new Config.Secret(stack, "MATE_SLACK_USER_ID");
 
   return [
     SLACK_LOG_LEVEL,
@@ -20,5 +25,7 @@ export function ConfigStack({ stack }: StackContext) {
     SLACK_SIGNING_SECRET,
     CORE_SLACK_CHANNEL_ID,
     RANDOM_SLACK_CHANNEL_ID,
+    KRISZTA_SLACK_USER_ID,
+    MATE_SLACK_USER_ID,
   ];
 }

--- a/tests/integration/createBirthdaySquad.test.ts
+++ b/tests/integration/createBirthdaySquad.test.ts
@@ -100,7 +100,7 @@ describe("CreateBirthdaySquad", () => {
         })),
       );
 
-      const eventId = "CS1_" + Date.now().toString();
+      const eventId = "CS2_" + Date.now().toString();
 
       await sendScheduleEvent(scheduleEvent, {
         eventId,

--- a/tests/integration/createBirthdaySquad.test.ts
+++ b/tests/integration/createBirthdaySquad.test.ts
@@ -1,0 +1,77 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { squadJoins, users } from "@/db/schema";
+import { timeout } from "@/testUtils/constants";
+import { deleteLastDm } from "@/testUtils/integration/deleteLastDm";
+import { sendScheduleEvent } from "@/testUtils/integration/sendScheduleEvent";
+import { waitForDm } from "@/testUtils/integration/waitForDm";
+import { testDb } from "@/testUtils/testDb";
+import { scheduleEvent } from "@/types/schedule";
+
+dayjs.extend(utc);
+
+const testSlackTeamId = import.meta.env.VITE_SLACK_TEAM_ID;
+const testUserId = import.meta.env.VITE_SLACK_USER_ID;
+const testBotUserId = import.meta.env.VITE_SLACK_BOT_USER_ID;
+
+const constants = vi.hoisted(() => ({
+  birthdayPerson: "U001",
+  eventId: "E001",
+  teamId: testSlackTeamId,
+  otherUserIds: [testUserId, testBotUserId],
+  converastionId: "CH001",
+}));
+
+describe("CreateBirthdaySquad", () => {
+  beforeAll(async () => {
+    await testDb.delete(users);
+    await testDb.delete(squadJoins);
+  });
+
+  afterEach(async () => {
+    await deleteLastDm();
+    await testDb.delete(users);
+    await testDb.delete(squadJoins);
+  });
+
+  it(
+    "Should publish sendWelcomeMessage to the conversation",
+    async () => {
+      await testDb.insert(users).values({
+        id: constants.birthdayPerson,
+        teamId: constants.teamId,
+        birthday: dayjs.utc().toDate(),
+      });
+
+      await testDb.insert(users).values(
+        constants.otherUserIds.map((userId) => ({
+          id: userId,
+          teamId: constants.teamId,
+          birthday: dayjs.utc().toDate(),
+        })),
+      );
+
+      const eventId = "CS1_" + Date.now().toString();
+
+      await sendScheduleEvent(scheduleEvent, {
+        eventId,
+        eventType: "createBirthdaySquad",
+        payload: {
+          team: import.meta.env.VITE_SLACK_TEAM_ID,
+          birthdayPerson: constants.birthdayPerson,
+          eventId,
+        },
+      });
+
+      const message = await waitForDm(eventId);
+
+      expect(message.metadata?.event_type, "EventType doesn't match").toEqual(
+        "sendSquadWelcomeMessage",
+      );
+      expect(message.text, "Message doesn't match").toEqual("Test message");
+    },
+    timeout,
+  );
+});

--- a/tests/integration/createBirthdaySquad.test.ts
+++ b/tests/integration/createBirthdaySquad.test.ts
@@ -21,13 +21,12 @@ const constants = vi.hoisted(() => ({
   eventId: "E001",
   teamId: testSlackTeamId,
   otherUserIds: [testUserId, testBotUserId],
-  converastionId: "CH001",
+  conversationId: "CH001",
 }));
 
 describe("CreateBirthdaySquad", () => {
   beforeAll(async () => {
     await testDb.delete(users);
-    await testDb.delete(squadJoins);
   });
 
   afterEach(async () => {

--- a/tests/unit/askPresentIdeasFromTeam.test.ts
+++ b/tests/unit/askPresentIdeasFromTeam.test.ts
@@ -126,6 +126,7 @@ describe("askPresentIdeasFromTeam", () => {
       askPresentIdeasFromTeam,
     );
 
+    expect(schedulerClient.send).toHaveBeenCalledTimes(1);
     expect(CreateScheduleCommand).toHaveBeenCalledWith(
       mockEventSchedulerPayload(
         "askPresentAndSquadJoinFromTeam",
@@ -137,7 +138,6 @@ describe("askPresentIdeasFromTeam", () => {
         4,
       ),
     );
-    expect(schedulerClient.send).toHaveBeenCalled();
   });
 
   it("Should publish createBirthdaySquad event with a schedule", async () => {

--- a/tests/unit/askPresentIdeasFromTeam.test.ts
+++ b/tests/unit/askPresentIdeasFromTeam.test.ts
@@ -126,7 +126,6 @@ describe("askPresentIdeasFromTeam", () => {
       askPresentIdeasFromTeam,
     );
 
-    expect(schedulerClient.send).toHaveBeenCalledTimes(1);
     expect(CreateScheduleCommand).toHaveBeenCalledWith(
       mockEventSchedulerPayload(
         "askPresentAndSquadJoinFromTeam",
@@ -138,6 +137,42 @@ describe("askPresentIdeasFromTeam", () => {
         4,
       ),
     );
+    expect(schedulerClient.send).toHaveBeenCalled();
+  });
+
+  it("Should publish createBirthdaySquad event with a schedule", async () => {
+    const event = {
+      birthdayPerson: constants.userId,
+      team: constants.teamId,
+      eventId: constants.eventId,
+    } satisfies Events["askPresentIdeasFromTeam"];
+
+    await testDb.insert(users).values(
+      constants.otherUserIds.map((userId) => ({
+        id: userId,
+        teamId: constants.teamId,
+        birthday: dayjs.utc().toDate(),
+      })),
+    );
+
+    await sendMockSqsMessage(
+      "askPresentIdeasFromTeam",
+      event,
+      askPresentIdeasFromTeam,
+    );
+
+    expect(CreateScheduleCommand).toHaveBeenCalledWith(
+      mockEventSchedulerPayload(
+        "createBirthdaySquad",
+        {
+          birthdayPerson: constants.userId,
+          team: constants.teamId,
+          eventId: constants.eventId,
+        },
+        8,
+      ),
+    );
+    expect(schedulerClient.send).toHaveBeenCalled();
   });
 
   it("Should not publish askPresentIdeasFromUser event for the one whose birthday is coming up", async () => {

--- a/tests/unit/askPresentIdeasFromTeam.test.ts
+++ b/tests/unit/askPresentIdeasFromTeam.test.ts
@@ -126,7 +126,7 @@ describe("askPresentIdeasFromTeam", () => {
       askPresentIdeasFromTeam,
     );
 
-    expect(schedulerClient.send).toHaveBeenCalledTimes(1);
+    expect(schedulerClient.send).toHaveBeenCalledTimes(2);
     expect(CreateScheduleCommand).toHaveBeenCalledWith(
       mockEventSchedulerPayload(
         "askPresentAndSquadJoinFromTeam",

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -90,7 +90,7 @@ describe("Final squad size is less then 2", () => {
     expect(openConversation).not.toBeCalled();
   });
 
-  it("Should not call publishEvent", async () => {
+  it("Should not publish sendSquadWelcomeMessage event", async () => {
     const getRandomSquadMembersSpy = vi.spyOn(
       getSquadMembers,
       "getRandomSquadMembers",
@@ -181,7 +181,7 @@ describe("3 or more squad members applied", () => {
     );
   });
 
-  it("Should publish sendSquadWelcomeMessage", async () => {
+  it("Should publish sendSquadWelcomeMessage event", async () => {
     await sendMockSqsMessage("createBirthdaySquad", event, handler);
 
     expect(PutEventsCommand).toHaveBeenCalledWith(

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -64,6 +64,7 @@ describe("CreateBirthdaySquad", () => {
     );
   });
 });
+
 describe("Final squad size is less then 2", () => {
   let openConversationMock: Mock;
   let eventBridge: EventBridgeClient;
@@ -100,6 +101,7 @@ describe("Final squad size is less then 2", () => {
 
     expect(openConversation).not.toBeCalled();
   });
+
   it("Should not call publishEvent", async () => {
     const event = {
       birthdayPerson: constants.birthdayPerson,
@@ -125,6 +127,7 @@ describe("Final squad size is less then 2", () => {
     expect(eventBridge.send).not.toBeCalled();
   });
 });
+
 describe("Applied squad members is less the 3", () => {
   let openConversationMock: Mock;
 
@@ -158,6 +161,7 @@ describe("Applied squad members is less the 3", () => {
     });
   });
 });
+
 describe("Applied squad members is 3 or more", () => {
   let openConversationMock: Mock;
   let insertedSquadMembers: string[];
@@ -210,6 +214,7 @@ describe("Applied squad members is 3 or more", () => {
 
     expect(getRandomSquadMembersSpy).not.toHaveBeenCalled();
   });
+
   it("Should call openConversation", async () => {
     const event = {
       birthdayPerson: constants.birthdayPerson,
@@ -225,6 +230,7 @@ describe("Applied squad members is 3 or more", () => {
       expect.arrayContaining(insertedSquadMembers),
     );
   });
+
   it("Should publish sendSquadWelcomeMessage", async () => {
     const event = {
       birthdayPerson: constants.birthdayPerson,

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -11,7 +11,7 @@ import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as getSquadMembers from "@/db/queries/getSquadMembers";
-import { users } from "@/db/schema";
+import { squadJoins, users } from "@/db/schema";
 import type { Events } from "@/events";
 import { handler } from "@/functions/events/createBirthdaySquad";
 import { BIRTHDAY_SQUAD_SIZE } from "@/functions/utils/constants";
@@ -47,6 +47,7 @@ describe("createBirthdaySquad", () => {
   afterEach(async () => {
     vi.clearAllMocks();
     await testDb.delete(users);
+    await testDb.delete(squadJoins);
   });
 
   it("Should call getSquadMembers", async () => {

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -1,0 +1,179 @@
+import "@/testUtils/unit/mockDb";
+import "@/testUtils/unit/mockEventBridge";
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as getSquadMembers from "@/db/queries/getSquadMembers";
+import { users } from "@/db/schema";
+import type { Events } from "@/events";
+import { handler } from "@/functions/events/createBirthdaySquad";
+import { BIRTHDAY_SQUAD_SIZE } from "@/functions/utils/constants";
+import { openConversation } from "@/services/slack/openConversation";
+import { seedSquadJoins } from "@/testUtils/seedSquadJoins";
+import { testDb } from "@/testUtils/testDb";
+import { sendMockSqsMessage } from "@/testUtils/unit/sendMockSqsMessage";
+
+dayjs.extend(utc);
+
+const constants = vi.hoisted(() => ({
+  birthdayPerson: "U001",
+  eventId: "E001",
+  teamId: "T001",
+  otherUserIds: ["U002", "U003", "U004", "U005", "U006"],
+  converastionId: "CH001",
+}));
+
+vi.mock("@/services/slack/openConversation", async () => ({
+  openConversation: vi.fn().mockResolvedValue(constants.converastionId),
+}));
+
+describe("createBirthdaySquad", () => {
+  let openConversationMock: Mock;
+  let eventBridge: EventBridgeClient;
+
+  beforeEach(() => {
+    openConversationMock = openConversation as Mock;
+    eventBridge = new EventBridgeClient();
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await testDb.delete(users);
+  });
+
+  it("Shoud call the getSquadMembers", async () => {
+    const event = {
+      birthdayPerson: constants.birthdayPerson,
+      eventId: constants.eventId,
+      team: constants.teamId,
+    } satisfies Events["createBirthdaySquad"];
+    const getSquadMembersSpy = vi.spyOn(getSquadMembers, "getSquadMembers");
+
+    openConversationMock.mockResolvedValueOnce(constants.converastionId);
+
+    await sendMockSqsMessage("createBirthdaySquad", event, handler);
+
+    expect(getSquadMembersSpy).toHaveBeenCalledWith(
+      constants.teamId,
+      constants.birthdayPerson,
+    );
+  });
+  it("Shoud not call the openConverstaion if the final squad size is less then 2", async () => {
+    const event = {
+      birthdayPerson: constants.birthdayPerson,
+      eventId: constants.eventId,
+      team: constants.teamId,
+    } satisfies Events["createBirthdaySquad"];
+    const getRandomSquadMembersSpy = vi.spyOn(
+      getSquadMembers,
+      "getRandomSquadMembers",
+    );
+
+    openConversationMock.mockResolvedValueOnce(constants.converastionId);
+
+    await sendMockSqsMessage("createBirthdaySquad", event, handler);
+
+    expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
+      teamId: constants.teamId,
+      usersToExclude: [constants.birthdayPerson],
+      limit: BIRTHDAY_SQUAD_SIZE,
+    });
+
+    expect(openConversation).not.toBeCalled();
+  });
+  it("Shoud not call the publishEvent if the final squad size is less then 2", async () => {
+    const event = {
+      birthdayPerson: constants.birthdayPerson,
+      eventId: constants.eventId,
+      team: constants.teamId,
+    } satisfies Events["createBirthdaySquad"];
+    const getRandomSquadMembersSpy = vi.spyOn(
+      getSquadMembers,
+      "getRandomSquadMembers",
+    );
+
+    openConversationMock.mockResolvedValueOnce(constants.converastionId);
+
+    await sendMockSqsMessage("createBirthdaySquad", event, handler);
+
+    expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
+      teamId: constants.teamId,
+      usersToExclude: [constants.birthdayPerson],
+      limit: BIRTHDAY_SQUAD_SIZE,
+    });
+
+    expect(PutEventsCommand).not.toBeCalled();
+    expect(eventBridge.send).not.toBeCalled();
+  });
+  it("Shoud call the getRandomSquadMembers if the appliedSquadMembers size less then 3", async () => {
+    const event = {
+      birthdayPerson: constants.birthdayPerson,
+      eventId: constants.eventId,
+      team: constants.teamId,
+    } satisfies Events["createBirthdaySquad"];
+    const getRandomSquadMembersSpy = vi.spyOn(
+      getSquadMembers,
+      "getRandomSquadMembers",
+    );
+
+    openConversationMock.mockResolvedValueOnce(constants.converastionId);
+
+    await sendMockSqsMessage("createBirthdaySquad", event, handler);
+
+    expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
+      teamId: constants.teamId,
+      usersToExclude: [constants.birthdayPerson],
+      limit: BIRTHDAY_SQUAD_SIZE,
+    });
+  });
+
+  it("Shoud call not the getRandomSquadMembers if the appliedSquadMembers size 3 or more", async () => {
+    const event = {
+      birthdayPerson: constants.birthdayPerson,
+      eventId: constants.eventId,
+      team: constants.teamId,
+    } satisfies Events["createBirthdaySquad"];
+    const getRandomSquadMembersSpy = vi.spyOn(
+      getSquadMembers,
+      "getRandomSquadMembers",
+    );
+
+    await testDb.insert(users).values({
+      id: constants.birthdayPerson,
+      teamId: constants.teamId,
+      birthday: dayjs.utc().toDate(),
+    });
+
+    await testDb.insert(users).values(
+      constants.otherUserIds.map((userId) => ({
+        id: userId,
+        teamId: constants.teamId,
+        birthday: dayjs.utc().toDate(),
+      })),
+    );
+
+    const insertedSquadMembers = await seedSquadJoins(
+      constants.birthdayPerson,
+      constants.teamId,
+      constants.otherUserIds,
+      3,
+    );
+
+    openConversationMock.mockResolvedValueOnce(constants.converastionId);
+
+    await sendMockSqsMessage("createBirthdaySquad", event, handler);
+
+    expect(getRandomSquadMembersSpy).not.toHaveBeenCalled();
+
+    expect(openConversation).toBeCalledWith(
+      expect.arrayContaining(insertedSquadMembers),
+    );
+  });
+});

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -188,7 +188,7 @@ describe("3 or more squad members applied", () => {
     );
   });
 });
-describe.only("Add admin to the squad", () => {
+describe("Add admin to the squad", () => {
   let insertedSquadMembers: string[];
 
   beforeAll(async () => {

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -104,7 +104,7 @@ describe("Final squad size is less then 2", () => {
   });
 });
 
-describe("3 or less squad members applied", () => {
+describe("2 or less squad members applied", () => {
   it("Should call getRandomSquadMembers", async () => {
     const getRandomSquadMembersSpy = vi.spyOn(
       getSquadMembers,

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -78,7 +78,7 @@ describe("Final squad size is less then 2", () => {
 
     expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
       teamId: constants.teamId,
-      usersToExclude: [constants.birthdayPerson],
+      usersToExclude: [constants.birthdayPerson, constants.krisztaUserId],
       limit: BIRTHDAY_SQUAD_SIZE,
     });
 
@@ -95,7 +95,7 @@ describe("Final squad size is less then 2", () => {
 
     expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
       teamId: constants.teamId,
-      usersToExclude: [constants.birthdayPerson],
+      usersToExclude: [constants.birthdayPerson, constants.krisztaUserId],
       limit: BIRTHDAY_SQUAD_SIZE,
     });
 
@@ -115,7 +115,7 @@ describe("3 or less squad members applied", () => {
 
     expect(getRandomSquadMembersSpy).toHaveBeenCalledWith({
       teamId: constants.teamId,
-      usersToExclude: [constants.birthdayPerson],
+      usersToExclude: [constants.birthdayPerson, constants.krisztaUserId],
       limit: BIRTHDAY_SQUAD_SIZE,
     });
   });

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -7,7 +7,15 @@ import {
 } from "@aws-sdk/client-eventbridge";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import * as getSquadMembers from "@/db/queries/getSquadMembers";
 import { squadJoins, users } from "@/db/schema";
@@ -50,34 +58,11 @@ vi.mock("sst/node/config", () => ({
   },
 }));
 
-describe("CreateBirthdaySquad", () => {
-  beforeEach(() => {});
-
-  afterEach(async () => {
-    vi.clearAllMocks();
-  });
-
-  it("Should call getSquadMembers", async () => {
-    const getSquadMembersSpy = vi.spyOn(getSquadMembers, "getSquadMembers");
-
-    await sendMockSqsMessage("createBirthdaySquad", event, handler);
-
-    expect(getSquadMembersSpy).toHaveBeenCalledWith(
-      constants.teamId,
-      constants.birthdayPerson,
-    );
-  });
-});
-
 describe("Final squad size is less then 2", () => {
   let eventBridge: EventBridgeClient;
 
   beforeEach(() => {
     eventBridge = new EventBridgeClient();
-  });
-
-  afterEach(async () => {
-    vi.clearAllMocks();
   });
 
   it("Should not call openConversation", async () => {
@@ -117,10 +102,6 @@ describe("Final squad size is less then 2", () => {
 });
 
 describe("3 or less squad members applied", () => {
-  afterEach(async () => {
-    vi.clearAllMocks();
-  });
-
   it("Should call getRandomSquadMembers", async () => {
     const getRandomSquadMembersSpy = vi.spyOn(
       getSquadMembers,
@@ -140,7 +121,10 @@ describe("3 or less squad members applied", () => {
 describe("3 or more squad members applied", () => {
   let insertedSquadMembers: string[];
 
-  beforeEach(async () => {
+  beforeAll(async () => {
+    await testDb.delete(users);
+    await testDb.delete(squadJoins);
+
     await testDb.insert(users).values({
       id: constants.birthdayPerson,
       teamId: constants.teamId,
@@ -163,7 +147,7 @@ describe("3 or more squad members applied", () => {
     );
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     vi.clearAllMocks();
     await testDb.delete(users);
     await testDb.delete(squadJoins);

--- a/tests/unit/createBirthdaySquad.test.ts
+++ b/tests/unit/createBirthdaySquad.test.ts
@@ -43,6 +43,13 @@ vi.mock("@/services/slack/openConversation", async () => ({
   openConversation: vi.fn().mockResolvedValue(constants.conversationId),
 }));
 
+vi.mock("sst/node/config", () => ({
+  Config: {
+    KRISZTA_SLACK_USER_ID: import.meta.env.VITE_SLACK_USER_ID,
+    MATE_SLACK_USER_ID: import.meta.env.VITE_SLACK_USER_ID,
+  },
+}));
+
 describe("CreateBirthdaySquad", () => {
   beforeEach(() => {});
 

--- a/tests/utils/seedSquadJoins.ts
+++ b/tests/utils/seedSquadJoins.ts
@@ -1,0 +1,22 @@
+import { squadJoins } from "@/db/schema";
+
+import { testDb } from "./testDb";
+
+export const seedSquadJoins = async (
+  birthdayPerson: string,
+  teamId: string,
+  userIds: string[],
+  count: number,
+) => {
+  const insertedSquadMembers = userIds.slice(0, count);
+
+  await testDb.insert(squadJoins).values(
+    insertedSquadMembers.map((userId) => ({
+      userId,
+      teamId: teamId,
+      birthdayPerson,
+    })),
+  );
+
+  return insertedSquadMembers;
+};


### PR DESCRIPTION
## Changes Made:

### 1. New Feature: Birthday Squad
- Added functionality to create a birthday squad for team members celebrating their birthdays.
- Introduced a new private conversation for squad members.
- If more than 5 team members express interest, randomly select 5 members. If fewer than 3, include random team members.
- Ensured a minimum of 2 users are selected to open a conversation.

### 2. Code Updates:
- Created new files:
  - `packages/core/db/queries/getSquadMembers.ts`: Contains queries to fetch and select squad members.
  - `packages/functions/events/createBirthdaySquad.ts`: Implements the logic for creating a birthday squad, including obtaining squad members and handling errors.
  - `tests/integration/createBirthdaySquad.test.ts` and `tests/unit/createBirthdaySquad.test.ts`: Added tests to ensure the functionality works as expected.
  - `tests/utils/seedSquadJoins.ts`: Utility for seeding squad joins data for testing.
  - `packages/core/services/slack/openConversation.ts`: Updated to open a conversation for the birthday squad.

### 3. Slack Permission Update:
- Added a new Slack permission: `mpim:write` to facilitate the creation of private multi-person direct messages for the birthday squad.

## Context:
This pull request introduces a new feature to create birthday squads for team members. It leverages existing functionalities for obtaining squad members and opening conversations. Additionally, a new Slack permission, `mpim:write`, is required for creating private multi-person direct messages.

## Testing:
- Unit and integration tests have been added to ensure the correct functioning of the birthday squad feature.
- Manual testing has been conducted to validate the creation of birthday squads under various scenarios.

## Dependencies:
No new external dependencies have been introduced.

## Additional Notes:
Ensure that the new Slack permission is properly documented in the project's Slack integration documentation.

