### PR TITLE
fix: don't send loading on checkbox check

### DIFF
--- a/packages/functions/lambdas/slack-interaction.ts
+++ b/packages/functions/lambdas/slack-interaction.ts
@@ -94,6 +94,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (request) => {
         });
         break;
       }
+      default:
+        return okResult();
     }
 
     await sendResponse(parsedData.response_url, constructLoadingMessage());


### PR DESCRIPTION
The slack interaction webhook sends an event for any interaction, including checkbox ones, which we ignore.
However the loading indicator did get triggered because we didn't return on unknown actions.